### PR TITLE
Travis node 0.12 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ cache:
   - node_modules
 before_install:
 - npm install -g semver
+install:
+- npm install
+# Ensure babel-cli is installed after babel in node.js 0.12
+- if [ "${TRAVIS_NODE_VERSION}" = "0.12" ]; then npm uninstall babel-cli && npm install babel-cli@"^6.4.5"; fi
 before_script:
 - npm run lint
 - npm run build


### PR DESCRIPTION
Travis: 

> I've reviewed the build log you sent and I think the problem is the order of installation of the babel vs babel-cli packages in both node versions i.e. in node 0.10, babel-cli is installed AFTER babel while babel-cli is installed BEFORE babel in node 0.12. This is probably due to the different npm versions in both builds i.e. node 0.10 uses npm 1.4.29 while node 0.12 uses 2.14.9.
> 
> I have the following workaround to suggest you. You can add the following to your .travis.yml file:
> 
> ```
> install:
>   - npm install
>   # Ensure babel-cli is installed after babel in node.js 0.12
>   - if [ "${TRAVIS_NODE_VERSION}" = "0.12" ]; then npm uninstall babel-cli && npm install babel-cli@"^6.4.5"; fi
> ```

