### PR TITLE
Explicitly cast plugin option strings to boolean

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -55,7 +55,12 @@ export function getSVGOOpts(argv) {
     svgoOpts = handlePath(argv.svgo);
   } else if (isPlainObject(argv.svgo)){
     svgoOpts = argv.svgo;
-    if (isPlainObject(svgoOpts.plugins) || typeof svgoOpts.plugins === 'string') {
+    if (isPlainObject(svgoOpts.plugins)) {
+      svgoOpts.plugins = Object.keys(svgoOpts.plugins).map((key) => {
+        return {[key]: svgoOpts.plugins[key] === "false" ? false : true}
+      });
+    }
+    else if (typeof svgoOpts.plugins === 'string') {
       svgoOpts.plugins = [svgoOpts.plugins];
     }
   }

--- a/test/cli.js
+++ b/test/cli.js
@@ -75,6 +75,26 @@ test('pass options to svgo', function(t) {
   }).catch(t.end);
 });
 
+test('disable svgo plugin', function(t) {
+  Promise.all([
+    exec('dummy.svg', '--svgo.plugins.sortAttrs', 'true'),
+    exec('dummy.svg', '--svgo.plugins.sortAttrs', 'false'),
+  ]).then(r => {
+    t.notEqual(r[0], r[1]);
+    t.end();
+  }).catch(t.end);
+});
+
+test('pass multiple svgo plugin options', function(t) {
+  Promise.all([
+    exec('dummy.svg', '--svgo.plugins.convertStyleToAttrs', 'false', '--svgo.plugins.sortAttrs', 'true'),
+    exec('dummy.svg', '--svgo.plugins.convertStyleToAttrs', 'false'),
+  ]).then(r => {
+    t.notEqual(r[0], r[1]);
+    t.end();
+  }).catch(t.end);
+});
+
 test('plugins options in svgo', function(t) {
   Promise.all([
     exec('dummy.svg'),


### PR DESCRIPTION
..as svgo requires boolean config properties. Fixes #76

Note: This also fixes a weakness where it wasn't possible to specify more than one `--svgo.plugins.<name> <true|false>` option.