### PR TITLE
Update README to be compatible with webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ npm i react-svg-loader
 
 ```js
 // without webpack loader config
-import Image1 from 'react-svg!./image1.svg';
+import Image1 from 'react-svg-loader!./image1.svg';
 
-// or if you're passing all .svg files via react-svg loader,
+// or if you're passing all .svg files via react-svg-loader,
 import Image2 from './image1.svg';
 
 // and use it like any other React Component
@@ -49,13 +49,13 @@ By default the loader outputs ES2015 code (with JSX compiled to JavaScript using
   test: /\.svg$/,
   loaders: [
     {
-      loader: 'babel',
+      loader: 'babel-loader',
       query: {
         presets: ['es2015']
       }
     },
     {
-      loader: 'react-svg',
+      loader: 'react-svg-loader',
       query: {
         jsx: true
       }
@@ -72,7 +72,7 @@ Pass loader query `jsx=true`.
 // In your webpack config
 {
   test: /\.svg$/,
-  loader: 'react-svg?jsx=1'
+  loader: 'react-svg-loader?jsx=1'
 }
 ```
 
@@ -83,7 +83,7 @@ Pass loader query `jsx=true`.
 ```js
 {
   test: /\.svg$/,
-  loader: 'react-svg',
+  loader: 'react-svg-loader',
   query: {
     svgo: {
       // svgo options
@@ -99,7 +99,7 @@ or if you're using with babel-loader, you can
 ```js
 {
   test: /\.svg$/,
-  loader: 'babel!react-svg?' + JSON.stringify({
+  loader: 'babel-loader!react-svg-loader?' + JSON.stringify({
     svgo: {
       // svgo options
       plugins: [{removeTitle: false}],
@@ -114,9 +114,12 @@ or if you're using with babel-loader, you can
 ```js
 {
   test: /\.svg$/,
-  loaders: [ 'babel',
+  use: [
     {
-      loader: 'react-svg',
+      loader: 'babel-loader'
+    },
+    {
+      loader: 'react-svg-loader',
       query: {
         svgo: {
           plugins: [{removeTitle: false}],


### PR DESCRIPTION
In webpack 2, the full name of every loader has to be supplied by default. Ei. it is not possible to use `react-svg` as the loader name, it has to be `react-svg-loader`.

Currently the README included some examples that didn't work when copy/pasted into webpack 2 config.

This commit updates the README to use the `-loader` suffix in **all** of the examples — including webpack v1. This was done because in some cases it is not clear whether the example is webpack 1 or 2. webpack 1 works **with** the suffix as well so I thought this is the least confusing way to solve this. (Didn't wanna duplicate all examples etc...)

A small tweak was also made to the webpack 2 config example, as it was using `loaders` instead of `use` property, which is no longer the canonical way.