### PR TITLE
Allow aria-* attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ or if you're using with babel-loader, you can
 }
 ```
 
+**If you want to use aria attributes in your SVGs**, set this SVGO plugin option:
+
+```js
+{ removeUnknownsAndDefaults: false }
+```
+
 #### Webpack 2.x
 
 ```js

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -38,7 +38,7 @@ export default function (babel) {
           );
         }
 
-        if (path.node.name.name.indexOf('data-') !== 0) {
+        if (!/^(data-|aria-)/.test(path.node.name.name)) {
           // converts
           // <svg stroke-width="5">
           // to

--- a/test/loader.js
+++ b/test/loader.js
@@ -5,7 +5,7 @@ import test from 'tape';
 import vm from 'vm';
 import {transform} from 'babel-core';
 
-function loader(content) {
+function loader(content, query) {
   return new Promise(function(resolve, reject) {
     let context = {
       cacheable() {},
@@ -22,7 +22,8 @@ function loader(content) {
           }).code, sandbox);
           resolve(sandbox.exports.default);
         }
-      }
+      },
+      query
     };
     reactSVGLoader.apply(context, [content]);
   });
@@ -113,6 +114,23 @@ test('should not convert data-* props', function(t) {
     .then(component => render(React.createElement(component)))
     .then(r => {
       t.equal(Object.keys(r.props).indexOf('data-foo'), 0, 'data-* shouldn\'t be camelCased')
+    })
+    .catch(t.end);
+});
+
+test('should not convert aria-* props', function(t) {
+  t.plan(1);
+
+  loader(`<svg aria-labelledby="foo"></svg>`, {
+    svgo: {
+      plugins: [
+        { removeUnknownsAndDefaults: false },
+      ]
+    }
+  })
+    .then(component => render(React.createElement(component)))
+    .then(r => {
+      t.equal(Object.keys(r.props).indexOf('aria-labelledby'), 0, 'aria-* shouldn\'t be camelCased')
     })
     .catch(t.end);
 });


### PR DESCRIPTION
Closes #166.

Unfortunately, looks like a bug in SVGO (https://github.com/svg/svgo/issues/684) means that by default aria-* attributes are stripped. So I added a note to the README about how to get aria-* attributes to pass through. Also needed to add an ability to test queries, so I could test this.