### PR TITLE
Rename `query` to `options` in webpack 2.x example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ or if you're using with babel-loader, you can
     },
     {
       loader: 'react-svg-loader',
-      query: {
+      options: {
         svgo: {
           plugins: [{removeTitle: false}],
           floatPrecision: 2


### PR DESCRIPTION
For some reason, my custom SVGO config wasn't being applied when I used `query: {...}`. Switching to `options: {...}` solved the issue.