### PR TITLE
Support for SVG in CSS files

### DIFF
--- a/packages/react-svg-loader/README.md
+++ b/packages/react-svg-loader/README.md
@@ -41,7 +41,8 @@ By default the loader outputs ES2015 code (with JSX compiled to JavaScript using
     {
       loader: "react-svg-loader",
       options: {
-        jsx: true // true outputs JSX tags
+        jsx: true, // true outputs JSX tags
+        match: /\.jsx?/, // files we want to transform using react-svg-loader
       }
     }
   ]

--- a/packages/react-svg-loader/package.json
+++ b/packages/react-svg-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-svg-loader",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Optimize svg and load it as a React Component",
   "keywords": [
     "loader",
@@ -25,6 +25,7 @@
     "url": "git+https://github.com/boopathi/react-svg-loader.git"
   },
   "dependencies": {
+    "is-svg": "^2.1.0",
     "loader-utils": "^1.1.0",
     "react-svg-core": "^2.1.0"
   }

--- a/packages/react-svg-loader/src/loader.js
+++ b/packages/react-svg-loader/src/loader.js
@@ -1,14 +1,36 @@
 // @flow
 
+import fs from 'fs';
+import isSvg from 'is-svg';
 import loaderUtils from "loader-utils";
 import { optimize, transform } from "react-svg-core";
 
 export default function(content: string) {
   const loaderOpts = loaderUtils.getOptions(this) || {};
 
+  if (loaderOpts.match && !loaderOpts.match.test(this._module.issuer.userRequest)) {
+    this.callback(null, content);
+    return;
+  }
+
   const cb = this.async();
 
   Promise.resolve(String(content))
+    .then(content => {
+      if (isSvg(content)) {
+        return content;
+      }
+
+      return new Promise((resolve, reject) => {
+        fs.readFile(this.resourcePath, 'utf-8', function (err, data) {
+          if (err !== null) {
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        });
+      });
+    })
     .then(optimize(loaderOpts.svgo))
     .then(transform({ jsx: loaderOpts.jsx }))
     .then(result => cb(null, result.code))

--- a/packages/react-svg-loader/src/loader.js
+++ b/packages/react-svg-loader/src/loader.js
@@ -1,14 +1,17 @@
 // @flow
 
-import fs from 'fs';
-import isSvg from 'is-svg';
+import fs from "fs";
+import isSvg from "is-svg";
 import loaderUtils from "loader-utils";
 import { optimize, transform } from "react-svg-core";
 
 export default function(content: string) {
   const loaderOpts = loaderUtils.getOptions(this) || {};
 
-  if (loaderOpts.match && !loaderOpts.match.test(this._module.issuer.userRequest)) {
+  if (
+    loaderOpts.match &&
+    !loaderOpts.match.test(this._module.issuer.userRequest)
+  ) {
     this.callback(null, content);
     return;
   }
@@ -22,7 +25,7 @@ export default function(content: string) {
       }
 
       return new Promise((resolve, reject) => {
-        fs.readFile(this.resourcePath, 'utf-8', function (err, data) {
+        fs.readFile(this.resourcePath, "utf-8", function(err, data) {
           if (err !== null) {
             reject(err);
           } else {


### PR DESCRIPTION
Shall resolve the issue mentioned in https://github.com/boopathi/react-svg-loader/issues/149
There is one extra option added, which needs to be defined.