### PR TITLE
issue-#205

### DIFF
--- a/packages/babel-plugin-react-svg/src/css-to-obj.js
+++ b/packages/babel-plugin-react-svg/src/css-to-obj.js
@@ -2,12 +2,14 @@
 
 export default function cssToObj(css: string) {
   let o = {};
-  let elements = css.split(";");
-  elements.filter(el => !!el).map(el => {
-    let s = el.split(":"),
-      key = s.shift().trim(),
-      value = s.join(":").trim();
-    o[key] = value;
-  });
+  if (typeof css !== "undefined") {
+    let elements = css.split(";");
+    elements.filter(el => !!el).map(el => {
+      let s = el.split(":"),
+        key = s.shift().trim(),
+        value = s.join(":").trim();
+      o[key] = value;
+    });
+  }
   return o;
 }


### PR DESCRIPTION
Example:
```
const style = { backgroundColor: red}
<div style={style} />
```

That will trigger an error 

> Cannot read property 'split' of undefined at cssToObj .../node_modules/babel-plugin-react-svg/lib/css-to-obj.js:9:21

This is the css-to-obj.js

```
export default function cssToObj(css: string) {
  let o = {};
  let elements = css.split(";");
  elements.filter(el => !!el).map(el => {
    let s = el.split(":"),
      key = s.shift().trim(),
      value = s.join(":").trim();
    o[key] = value;
  });
  return o;
}
```
My solution 
```
export default function cssToObj(css: string) {
  let o = {};
  if (typeof css !== "undefiend") {
   let elements = css.split(";");
  elements.filter(el => !!el).map(el => {
    let s = el.split(":"),
      key = s.shift().trim(),
      value = s.join(":").trim();
    o[key] = value;
  });
 }
  return o;
}
```
