### PR TITLE
Update to use fully resolved paths for babel plugins

### DIFF
--- a/packages/react-svg-core/src/index.js
+++ b/packages/react-svg-core/src/index.js
@@ -22,6 +22,10 @@ export function transform(
     babelTransform(content, {
       babelrc: false,
       presets: [jsx ? void 0 : "react"].filter(Boolean),
-      plugins: ["syntax-jsx", "transform-object-rest-spread", plugin]
+      plugins: [
+        require.resolve("babel-plugin-syntax-jsx"),
+        require.resolve("babel-plugin-transform-object-rest-spread"),
+        plugin
+      ]
     });
 }


### PR DESCRIPTION
Babel will resolve plugins relative to the cwd (this may be a slight simplification). This usually works as expected, however, I have stumbled on an edge case when using a monorepo structure with abstracted build configuration.

```
/packages
  /shared-build
    /node_modules
      + react-svg-loader
      + babel-plugin-syntax-jsx
      + babel-plugin-transform-object-rest-spread
  /app
    /node_modules
      + shared-build // symlink
```

In this case, babel is unable to resolve the plugins which live within the `node_modules` directory of the symlinked package, `shared-build`.

While slightly more verbose, we can bypass this problem by utilizing the full paths to the plugins that are installed relative to this package.