### PR TITLE
fix(react-svg-core): prevent arrow function output with extra plugin

### DIFF
--- a/packages/react-svg-core/package.json
+++ b/packages/react-svg-core/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-react-svg": "^2.1.0",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-preset-react": "^6.24.1",
     "lodash.isplainobject": "^4.0.6",
     "svgo": "^1.0.5"

--- a/packages/react-svg-core/src/index.js
+++ b/packages/react-svg-core/src/index.js
@@ -25,6 +25,7 @@ export function transform({
       plugins: [
         require.resolve("babel-plugin-syntax-jsx"),
         require.resolve("babel-plugin-transform-object-rest-spread"),
+        require.resolve("babel-plugin-transform-es2015-arrow-functions"),
         plugin
       ]
     });


### PR DESCRIPTION
## issue

The output has an arrow function in it.  This PR adds a new babel plugin to remove the arrow function from the output.

## setup

When using rollup with the following config: 

```js
const svgPlugin = require('rollup-plugin-react-svg');
...
svgPlugin({
     svgo: {
          plugins: [{ convertShapeToPath: false }, { cleanupIDs: false }],
     },
}),
```

## Code examples

To test it was react-svg-loader rather than my own setup, I have checked the output of non-svg code.

*non-svg example:*

```js
// source
const test = () => { return 'test'; };

// output
'use strict';

Object.defineProperty(exports, '__esModule', { value: true });

var test = function test() {
  return 'test';
};

```

*svg example:*

```js
// source
import Svg from './svg.svg';
console.log(Svg);

// output
'use strict';

function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }

var React = _interopDefault(require('react'));

var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };

function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
var Svg = ((_ref) => {
  let props = _objectWithoutProperties(_ref, ["styles"]);

  return React.createElement(
    "svg",
    _extends({ xmlns: "http://www.w3.org/2000/svg", width: "512", height: "512", viewBox: "0 0 512 512" }, props),
    React.createElement("path", { d: "M258.4 247.6c26.8 0 48.5-21.7 48.5-48.5s-22-48-49-48-48 21.4-48 48 21.5 48.7 48.3 48.7zm0-84.6c20 0 36 16 36 36s-16 36.2-36 36.2-36-16.2-36-36 16-36.2 36-36.2z" })
  );
});

console.log(Svg);
```

## Output with PR

```js
'use strict';

function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }

var React = _interopDefault(require('react'));

var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };

function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
var Svg = (function (_ref) {
  let props = _objectWithoutProperties(_ref, ["styles"]);

  return React.createElement(
        "svg",
  _extends({ xmlns: "http://www.w3.org/2000/svg", width: "512", height: "512", viewBox: "0 0 512 512" }, props),
  React.createElement("path", { d: "M258.4 247.6c26.8 0 48.5-21.7 48.5-48.5s-22-48-49-48-48 21.4-48 48 21.5 48.7 48.3 48.7zm0-84.6c20 0 36 16 36 36s-16 36.2-36 36.2-36-16.2-36-36 16-36.2 36-36.2z" })
);
});

  console.log(Svg);

```