### PR TITLE
Update SVGO to version 1.3.2

### DIFF
--- a/packages/react-svg-core/package.json
+++ b/packages/react-svg-core/package.json
@@ -27,7 +27,7 @@
     "babel-plugin-react-svg": "^3.0.3",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isplainobject": "^4.0.6",
-    "svgo": "^1.2.2"
+    "svgo": "^1.3.2"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
Update to the newest version to get access to e.g. `prefixIds`, that would help with the issue reported here https://github.com/boopathi/react-svg-loader/issues/218

See SVGO release notes here https://github.com/svg/svgo/releases